### PR TITLE
Fixed incorrect punctuation placing

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,7 @@
             experience of services like
             <a href="https://aws.amazon.com/lambda/">AWS Lambda</a>
             and
-            <a href="https://aws.amazon.com/fargate/">AWS Fargate</a>
-            .
+            <a href="https://aws.amazon.com/fargate/">AWS Fargate</a>.
           </p>
           <p>
             Firecracker is a virtual machine monitor (VMM) that uses the Linux Kernel-based Virtual Machine (KVM) to
@@ -93,24 +92,20 @@
               href="https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support"
             >
               Kata Containers
-            </a>
-            ,
-            <a href="https://opennebula.io/firecracker/">Open Nebula</a>
-            ,
-            <a href="https://github.com/solo-io/unik">UniK</a>
-            ,
+            </a>,
+            <a href="https://opennebula.io/firecracker/">Open Nebula</a>,
+            <a href="https://github.com/solo-io/unik">UniK</a>,
             <a href="https://www.weave.works/oss/firekube/">Weave FireKube</a>
             (via
             <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>
             ), and containerd via
             <a href="https://github.com/firecracker-microvm/firecracker-containerd">firecracker-containerd</a>
             It's also used by
-            <a href="https://fly.io/">fly.io</a>
-            . Firecracker can run Linux and
+            <a href="https://fly.io/">fly.io</a>. 
+            Firecracker can run Linux and
             <a href="http://blog.osv.io/blog/2019/04/19/making-OSv-run-on-firecraker">OSv</a>
             guests. Our latest roadmap can be found
-            <a href="https://github.com/firecracker-microvm/firecracker/projects/13">here</a>
-            .
+            <a href="https://github.com/firecracker-microvm/firecracker/projects/13">here</a>.
           </p>
         </section>
       </article>
@@ -267,14 +262,12 @@
                 href="https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support"
               >
                 Kata Containers
-              </a>
-              ,
+              </a>,
               <a href="https://www.weave.works/oss/firekube/">Weave FireKube</a>
               (via
               <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>
               ), and containerd via
-              <a href="https://github.com/firecracker-microvm/firecracker-containerd">firecracker-containerd</a>
-              .
+              <a href="https://github.com/firecracker-microvm/firecracker-containerd">firecracker-containerd</a>.
             </section>
           </article>
           <article class="m-item">
@@ -308,8 +301,8 @@
               <a href="https://github.com/firecracker-microvm/firecracker/blob/master/LICENSE">licensed</a>
               under the Apache License, version 2.0, allowing you to freely use, copy, and distribute your changes under
               the terms of your choice.
-              <a href="https://www.apache.org/licenses/LICENSE-2.0">Read more about Apache 2.0</a>
-              . Crosvm code sections are licensed under a
+              <a href="https://www.apache.org/licenses/LICENSE-2.0">Read more about Apache 2.0</a>. 
+              Crosvm code sections are licensed under a
               <a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a>
               that also allows you to use, copy, and distribute your changes under the terms of your choice.
             </section>
@@ -319,18 +312,17 @@
             <section>
               Firecracker is an AWS open source project that encourages contributions from customers and the developer
               community. Any contribution is welcome as long as it aligns with our
-              <a href="https://github.com/firecracker-microvm/firecracker/blob/master/CHARTER.md">charter</a>
-              . You can learn more about how to contribute in
+              <a href="https://github.com/firecracker-microvm/firecracker/blob/master/CHARTER.md">charter</a>. 
+              You can learn more about how to contribute in
               <a href="https://github.com/firecracker-microvm/firecracker/blob/master/CONTRIBUTING.md">
                 CONTRIBUTING.md
-              </a>
-              . You can chat with others in the community on the
+              </a>. 
+              You can chat with others in the community on the
               <a
                 href="https://join.slack.com/t/firecracker-microvm/shared_invite/enQtNDY2NTUwMzQ3MDE1LWIwMzA0OWFkMTZhMTlmMDZiMmFkYjMyODMxMGQ1ZjliMzJjNjJiNWRhNWNkOGEyNmUxNmRkMjZhYTc3MmVjZjM"
               >
                 Firecracker Slack workspace
-              </a>
-              .
+              </a>.
             </section>
           </article>
         </div>

--- a/index.html
+++ b/index.html
@@ -97,8 +97,8 @@
             <a href="https://github.com/solo-io/unik">UniK</a>,
             <a href="https://www.weave.works/oss/firekube/">Weave FireKube</a>
             (via
-            <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>
-            ), and containerd via
+            <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>), 
+            and containerd via
             <a href="https://github.com/firecracker-microvm/firecracker-containerd">firecracker-containerd</a>
             It's also used by
             <a href="https://fly.io/">fly.io</a>. 
@@ -192,8 +192,8 @@
             same machine. This means that every function, container, or container group can be encapsulated with a
             virtual machine barrier, enabling workloads from different customers to run on the same machine, without any
             tradeoffs to security or efficiency. Firecracker is an
-            <a href="https://www.redhat.com/en/blog/all-you-need-know-about-kvm-userspace">alternative to QEMU</a>
-            , an established VMM with a general purpose and broad feature set that allows it to host a variety of guest
+            <a href="https://www.redhat.com/en/blog/all-you-need-know-about-kvm-userspace">alternative to QEMU</a>, 
+            an established VMM with a general purpose and broad feature set that allows it to host a variety of guest
             operating systems.
           </p>
           <p>
@@ -223,8 +223,8 @@
               <a href="https://aws.amazon.com/fargate/">AWS Fargate</a>
               to improve resource utilization and customer experience, while providing the security and isolation
               required of public cloud infrastructure. Firecracker started from Chromium OS's Virtual Machine Monitor,
-              <a href="https://chromium.googlesource.com/chromiumos/platform/crosvm/">crosvm</a>
-              , an open source VMM written in Rust. Today, crosvm and Firecracker have diverged to serve very different
+              <a href="https://chromium.googlesource.com/chromiumos/platform/crosvm/">crosvm</a>, 
+              an open source VMM written in Rust. Today, crosvm and Firecracker have diverged to serve very different
               customer needs.
               <a href="https://github.com/rust-vmm">Rust-vmm</a>
               is an open source community where we collaborate with crosvm and other groups and individuals to build and
@@ -265,8 +265,8 @@
               </a>,
               <a href="https://www.weave.works/oss/firekube/">Weave FireKube</a>
               (via
-              <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>
-              ), and containerd via
+              <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>), 
+              and containerd via
               <a href="https://github.com/firecracker-microvm/firecracker-containerd">firecracker-containerd</a>.
             </section>
           </article>


### PR DESCRIPTION
## Reason for this PR

It had extra spaces between words and punctuation:
<img width="1162" alt="Снимок экрана 2020-10-16 в 11 41 10" src="https://user-images.githubusercontent.com/4660275/96236571-e4a4f080-0fa4-11eb-8bb0-6d28d1001dd0.png">


## License acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT-0 [1] license.

[1] https://github.com/aws/mit-0

## PR checklist

`[Author TODO: Meet these criteria & check the boxes.]`
`[Reviewer TODO: Verify checked boxes. Request changes if criteria not met]`

- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [x] All commits in this PR are signed (`git commit -s`).
