### PR TITLE
Update index.html to reflect that Firecracker is now GA on Arm and AMD - part 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,8 +261,8 @@
           <article class="m-item">
             <header>What processors does Firecracker support?</header>
             <section>
-              The Firecracker VMM is built to be processor agnostic. Intel processors are supported for production
-              workloads. Support for AMD and Arm processors is in developer preview.
+              The Firecracker VMM is built to be processor agnostic. 64-bit Intel, AMD and Arm CPUs with hardware
+              virtualization support are generally available for production workloads.
             </section>
           </article>
           <article class="m-item">


### PR DESCRIPTION
## Reason for this PR

The webpage wasn't updated with the new supported platforms when we released them in v0.23. Forgot a reference to developer preview in my previous PR - https://github.com/firecracker-microvm/firecracker-microvm.github.io/pull/20.

## Description of changes

Update index.html to reflect that Firecracker is GA for Intel, Arm and AMD.
Fixes #14

## License acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT-0 [1] license.

[1] https://github.com/aws/mit-0

## PR checklist

`[Author TODO: Meet these criteria & check the boxes.]`
`[Reviewer TODO: Verify checked boxes. Request changes if criteria not met]`

- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] All commits in this PR are signed (`git commit -s`).
