### PR TITLE
chore: Update Slack invitation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
             <span>Join our GitHub Community</span>
           </a>
           <a
-            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1fecwrorm-x5URTlOzBR2fExTU2mWfug"
+            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1zlb87h4z-NED1rBhVqOQ1ygBgT76wlg"
             class="css-button sta-hoverOFF"
           >
             <i class="icon-slack" aria-hidden="true"></i>
@@ -358,7 +358,7 @@
               </a>
               . You can chat with others in the community on the
               <a
-                href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1fecwrorm-x5URTlOzBR2fExTU2mWfug"
+                href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1zlb87h4z-NED1rBhVqOQ1ygBgT76wlg"
               >
                 Firecracker Slack workspace
               </a>
@@ -421,7 +421,7 @@
             <span>Join our GitHub Community</span>
           </a>
           <a
-            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1fecwrorm-x5URTlOzBR2fExTU2mWfug"
+            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1zlb87h4z-NED1rBhVqOQ1ygBgT76wlg"
             class="css-button3 sta-hoverOFF"
           >
             <i class="icon-slack" aria-hidden="true"></i>


### PR DESCRIPTION
Updated the expired Firecracker slack workspace link in index.html with a new valid one.

## Reason for this PR

Current Slack invitation link expired and does not allow new users to join our Slack workspace.

## Description of changes

Updated the slack workspace link in the index.html file with a new valid one.

## License acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT-0 [1] license.

[1] https://github.com/aws/mit-0

## PR checklist

- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] All commits in this PR are signed (`git commit -s`).
