### PR TITLE
Update copyright date

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,7 +434,7 @@
           <a href="#home">
             <img src="img/firecracker-logo@3x.png" alt="Firecracker logo" />
           </a>
-          <div>©2018-2021, Amazon Web Services, Inc. or its affiliates. All rights reserved.</div>
+          <div>©2018-2023, Amazon Web Services, Inc. or its affiliates. All rights reserved.</div>
         </div>
       </footer>
     </section>


### PR DESCRIPTION
Extend the copyright date to the year 2023.

## Reason for this PR

The current copyright date range is stopping to 2021 but in reality we updated the website both in 2022 and 2023 therefore we want to extend our right to this year. 

## Description of changes

Updated the copyright at the footer of the page to include in the range the years 2022 and 2023. 

## License acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT-0 [1] license.

[1] https://github.com/aws/mit-0

## PR checklist

- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] All commits in this PR are signed (`git commit -s`).
