### PR TITLE
Fix slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
             <span>Join our GitHub Community</span>
           </a>
           <a
-            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1zlb87h4z-NED1rBhVqOQ1ygBgT76wlg"
+            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-2tc0mfxpc-tU~HYAYSzLDl5XGGJU3YIg"
             class="css-button sta-hoverOFF"
           >
             <i class="icon-slack" aria-hidden="true"></i>
@@ -330,7 +330,7 @@
               </a>
               . You can chat with others in the community on the
               <a
-                href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1zlb87h4z-NED1rBhVqOQ1ygBgT76wlg"
+                href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-2tc0mfxpc-tU~HYAYSzLDl5XGGJU3YIg"
               >
                 Firecracker Slack workspace
               </a>
@@ -393,7 +393,7 @@
             <span>Join our GitHub Community</span>
           </a>
           <a
-            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1zlb87h4z-NED1rBhVqOQ1ygBgT76wlg"
+            href="https://join.slack.com/t/firecracker-microvm/shared_invite/zt-2tc0mfxpc-tU~HYAYSzLDl5XGGJU3YIg"
             class="css-button3 sta-hoverOFF"
           >
             <i class="icon-slack" aria-hidden="true"></i>

--- a/index.html
+++ b/index.html
@@ -406,7 +406,7 @@
           <a href="#home">
             <img src="img/firecracker-logo@3x.png" alt="Firecracker logo" />
           </a>
-          <div>©2018-2023, Amazon Web Services, Inc. or its affiliates. All rights reserved.</div>
+          <div>©2018-2025, Amazon Web Services, Inc. or its affiliates. All rights reserved.</div>
         </div>
       </footer>
     </section>


### PR DESCRIPTION
## Reason for this PR

The slack link expired, let's put the new one.

Ideally we'd have a redirect but for now let's keep it like this.

## Description of changes

Change link to https://join.slack.com/t/firecracker-microvm/shared_invite/zt-2tc0mfxpc-tU~HYAYSzLDl5XGGJU3YIg

## License acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT-0 [1] license.

[1] https://github.com/aws/mit-0

## PR checklist

- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] All commits in this PR are signed (`git commit -s`).
