### PR TITLE
fix: bump jquery version to latest

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1" />
     <link rel="icon" type="image/png" href="img/Favicon.png" />
     <link rel="stylesheet" href="style.css" />
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <script src="js/masonry.pkgd.min.js"></script>
     <script src="js/scripts.js" defer></script>
     <title>Firecracker</title>


### PR DESCRIPTION
## Reason for this PR

jquery versions older than 3.5.0 is known to introduce cross-site scripting and prototype pollution vulnerabilities. We're not really affected by this (we're just serving HTML), but let's just bump this to avoid security scanning tools complaining.

## Description of changes

Just bump the version to latest (3.7.1) for `jquery`.

## License acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT-0 [1] license.

[1] https://github.com/aws/mit-0

## PR checklist

`[Author TODO: Meet these criteria & check the boxes.]`
`[Reviewer TODO: Verify checked boxes. Request changes if criteria not met]`

- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] All commits in this PR are signed (`git commit -s`).
