### PR TITLE
remove weave.works links

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,8 +101,6 @@
             <a href="https://opennebula.io/firecracker/">OpenNebula</a>,
             <a href="https://www.qovery.com">Qovery</a>,
             <a href="https://github.com/solo-io/unik">UniK</a>,
-            <a href="https://www.weave.works/oss/firekube/">Weave FireKube</a>
-            (via <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>),
             <a href="https://webapp.io">webapp.io</a>, and
             <a href="https://github.com/astro/microvm.nix">microvm.nix</a>.
             Firecracker can run Linux and
@@ -273,10 +271,6 @@
               <a href="https://opennebula.io/firecracker/">OpenNebula</a>,
               <a href="https://www.qovery.com">Qovery</a>,
               <a href="https://github.com/solo-io/unik">UniK</a>,
-              <a href="https://www.weave.works/oss/firekube/">Weave FireKube</a>
-              (via
-              <a href="https://github.com/weaveworks/ignite">Weave Ignite</a>
-              ),
               <a href="https://webapp.io">webapp.io</a>, and
               <a href="https://github.com/astro/microvm.nix">microvm.nix</a>.
             </section>


### PR DESCRIPTION
## Reason for this PR

The weave.works links on the homepage (Weave FireKube, etc.) now redirect to a gambling scam site. Closes #39

## Description of changes

Removes the links

## License acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT-0 [1] license.

[1] https://github.com/aws/mit-0

## PR checklist

`[Author TODO: Meet these criteria & check the boxes.]`
`[Reviewer TODO: Verify checked boxes. Request changes if criteria not met]`

- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] All commits in this PR are signed (`git commit -s`).
